### PR TITLE
[UPDATE] remove license holder option/prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ For a general overview of Yeoman generators, see the [Getting Started Guide](htt
 $ npm install -g generator-compute-io
 ```
 
-## Usage 
+## Usage
 
 Once installed, navigate to the directory in which you want to place generated files and run
 
@@ -43,7 +43,7 @@ The module name requires the convention that the module be prefixed with `comput
 
 Valid names include: `compute-mean`, `compute-variance`, `compute-sum`, etc. Do __not__ include spaces or special characters in the name; e.g., `compute io correlation @ value`.
 
-Also note that using the generator requires internet access, as module name availability is confirmed on NPM via [npm-name](https://github.com/sindresorhus/npm-name). 
+Also note that using the generator requires internet access, as module name availability is confirmed on NPM via [npm-name](https://github.com/sindresorhus/npm-name).
 
 
 #### Git
@@ -77,13 +77,6 @@ Enter the primary author's name; i.e., in all likelihood that will be your name.
 If you have chosen to initialize the directory as a Git repository, the default will be the email associated with your Github account. This email should be a correspondence address for those individuals wanting to contact you directly with their questions and comments.
 
 If the Github email address is fine, just type `enter`.
-
-
-#### License
-
-Enter the license holder for this module. The default is your name, but this could be the organization for which you work (say, if they are helping sponsor development) or some other entity.
-
-If the default option is fine, just type `enter`.
 
 
 #### Description

--- a/TODO.md
+++ b/TODO.md
@@ -11,6 +11,3 @@ TODO
 ### Tests
 
 1. 	Prompts
-
-
-

--- a/app/index.js
+++ b/app/index.js
@@ -155,14 +155,6 @@ var Generator = yeoman.generators.Base.extend({
 			},
 			{
 				'type': 'input',
-				'name': 'license_holder',
-				'message': 'Author name(s) to include in the license file?',
-				default: function( answers ) {
-					return answers.author;
-				}
-			},
-			{
-				'type': 'input',
 				'name': 'description',
 				'message': 'Module description:',
 				'default': 'Compute module.'
@@ -173,7 +165,6 @@ var Generator = yeoman.generators.Base.extend({
 		this.prompt( prompts, function onAnswers( answers ) {
 			this.author = answers.author;
 			this.email = answers.email;
-			this.license_holder = answers.license_holder;
 			this.moduleName = answers.name;
 			this.description = answers.description;
 			this.git = answers.git;
@@ -222,7 +213,6 @@ var Generator = yeoman.generators.Base.extend({
 	*/
 	license: function() {
 		var context = {
-			'holder': this.license_holder,
 			'year': this.year
 		};
 

--- a/app/templates/_LICENSE
+++ b/app/templates/_LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) <%= year %> <%= holder %>.
+Copyright (c) <%= year %> The Compute.io Authors. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/app/templates/_README.md
+++ b/app/templates/_README.md
@@ -69,12 +69,12 @@ $ make view-cov
 ---
 ## License
 
-[MIT license](http://opensource.org/licenses/MIT). 
+[MIT license](http://opensource.org/licenses/MIT).
 
 
 ## Copyright
 
-Copyright &copy; <%= year %>. <%= author %>.
+Copyright &copy; <%= year %>. The Compute.io Authors.
 
 
 [npm-image]: http://img.shields.io/npm/v/<%= name %>.svg

--- a/package.json
+++ b/package.json
@@ -8,7 +8,16 @@
     "url": "https://github.com/kgryte"
   },
   "contributors": [
-    {}
+    {
+      "name": "Athan Reines",
+      "email": "kgryte@gmail.com",
+      "url": "https://github.com/kgryte"
+    },
+    {
+      "name": "Philipp Burckhardt",
+      "email": "pburckhardt@outlook.com",
+      "url": "https://github.com/Planeshifter"
+    }
   ],
   "scripts": {
     "test": "./node_modules/.bin/mocha",
@@ -35,7 +44,7 @@
   "dependencies": {
     "chalk": "^1.0.0",
     "npm-name": "^1.0.1",
-    "shelljs": "^0.4.0",
+    "shelljs": "^0.5.0",
     "yeoman-generator": "^0.18.9",
     "yosay": "^1.0.0"
   },
@@ -45,7 +54,7 @@
     "coveralls": "^2.11.1",
     "istanbul": "^0.3.0",
     "jshint": "2.x.x",
-    "jshint-stylish": "^1.0.0"
+    "jshint-stylish": "^2.0.0"
   },
   "peerDependencies": {
     "yo": ">=1.0.0"

--- a/test/test.creation.js
+++ b/test/test.creation.js
@@ -31,7 +31,6 @@ describe( 'compute-io generator', function tests() {
 				'name': 'compute-generator-test',
 				'author': 'Jane Doe',
 				'email': 'jane@doe.com',
-				'license_holder': 'Jane Doe &lt;jane@doe.com&gt;',
 				'description': 'Compute.io generator test module.',
 				'git': false
 			})


### PR DESCRIPTION
- changed LICENSE file to always have license holder "The Compute.io Authors. All rights reserved." 
- changed copyright notice in created README.md to "Copyright © <%= year %>. The Compute.io Authors."
- removed option/prompt to specify license holder
